### PR TITLE
Money Formatting Issue #1

### DIFF
--- a/src/money.php
+++ b/src/money.php
@@ -29,5 +29,5 @@ function preciseCalc() {
 }
 
 function f($money) {
-    return round($money, 2);
+    return sprintf("%.2f", round($money, 2));
 }

--- a/test/money.spec.php
+++ b/test/money.spec.php
@@ -48,7 +48,7 @@ describe('Money', function() {
     });
     describe('#f', function() {
         it('formats money by rounding it to two decimal places', function() {
-            assert(money\f(12.015) === 12.02);
+            assert(money\f(12.015) === '12.02' && money\f('1') === '1.00');
         });
     });
     describeCalculator(new Money\BCMathCalculator(), 'BCMathCalculator');


### PR DESCRIPTION
- Money formatting now always returns a string
  in the form of `x.xx` even if it's a whole
  number

Signed-off-by: RJ Garcia <rj@bighead.net>